### PR TITLE
Make trait functions immutable

### DIFF
--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -148,11 +148,7 @@ pub trait BuildAllocRef: Sized {
     /// * `layout` must *fit* that block of memory
     /// * the alignment of the `layout` must match the alignment used to allocate that block of
     ///   memory
-    unsafe fn build_alloc_ref(
-        &self,
-        ptr: NonNull<u8>,
-        layout: Option<NonZeroLayout>,
-    ) -> Self::Ref;
+    unsafe fn build_alloc_ref(&self, ptr: NonNull<u8>, layout: Option<NonZeroLayout>) -> Self::Ref;
 }
 
 pub trait DeallocRef: Sized {

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -182,7 +182,7 @@ impl<T, A: AllocRef> Box<T, A> {
     /// # #[allow(unused_variables)]
     /// let five = Box::new_in(5, Global);
     /// ```
-    #[allow(clippy::inline_always)]
+    #[allow(clippy::inline_always, clippy::needless_pass_by_value)]
     #[inline(always)]
     pub fn new_in(x: T, a: A) -> Self {
         unsafe { Self::try_new_in(x, a).unwrap_unchecked() }
@@ -201,6 +201,7 @@ impl<T, A: AllocRef> Box<T, A> {
     /// let five = Box::try_new_in(5, Global)?;
     /// # Ok::<_, alloc_wg::alloc::AllocErr>(())
     /// ```
+    #[allow(clippy::needless_pass_by_value)]
     pub fn try_new_in(x: T, a: A) -> Result<Self, A::Error> {
         let ptr = if let Ok(layout) = NonZeroLayout::new::<T>() {
             let ptr = a.alloc(layout)?.cast::<T>();
@@ -232,7 +233,7 @@ impl<T, A: AllocRef> Box<T, A> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[allow(clippy::inline_always)]
+    #[allow(clippy::inline_always, clippy::needless_pass_by_value)]
     #[inline(always)]
     pub fn new_uninit_in(a: A) -> Box<mem::MaybeUninit<T>, A> {
         unsafe { Self::try_new_uninit_in(a).unwrap_unchecked() }
@@ -257,6 +258,7 @@ impl<T, A: AllocRef> Box<T, A> {
     /// assert_eq!(*five, 5);
     /// # Ok::<_, alloc_wg::alloc::AllocErr>(())
     /// ```
+    #[allow(clippy::needless_pass_by_value)]
     pub fn try_new_uninit_in(a: A) -> Result<Box<mem::MaybeUninit<T>, A>, A::Error> {
         let ptr = if let Ok(layout) = NonZeroLayout::new::<T>() {
             let ptr: NonNull<mem::MaybeUninit<T>> = a.alloc(layout)?.cast();
@@ -269,7 +271,7 @@ impl<T, A: AllocRef> Box<T, A> {
 
     /// Constructs a new `Pin<Box<T, A>>` with the specified allocator. If `T` does not implement
     /// `Unpin`, then `x` will be pinned in memory and unable to be moved.
-    #[allow(clippy::inline_always)]
+    #[allow(clippy::inline_always, clippy::needless_pass_by_value)]
     #[inline(always)]
     pub fn pin_in(x: T, a: A) -> Pin<Self> {
         unsafe { Self::try_pin_in(x, a).unwrap_unchecked() }
@@ -277,6 +279,7 @@ impl<T, A: AllocRef> Box<T, A> {
 
     /// Constructs a new `Pin<Box<T, A>>` with the specified allocator. If `T` does not implement
     /// `Unpin`, then `x` will be pinned in memory and unable to be moved.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn try_pin_in(x: T, a: A) -> Result<Pin<Self>, A::Error> {
         Self::try_new_in(x, a).map(Pin::from)
@@ -335,7 +338,7 @@ impl<T, A: AllocRef> Box<[T], A> {
     ///
     /// assert_eq!(*values, [1, 2, 3]);
     /// ```
-    #[allow(clippy::inline_always)]
+    #[allow(clippy::inline_always, clippy::needless_pass_by_value)]
     #[inline(always)]
     pub fn new_uninit_slice_in(len: usize, a: A) -> Box<[mem::MaybeUninit<T>], A> {
         unsafe { Self::try_new_uninit_slice_in(len, a).unwrap_unchecked() }
@@ -363,6 +366,7 @@ impl<T, A: AllocRef> Box<[T], A> {
     /// assert_eq!(*values, [1, 2, 3]);
     /// # Ok::<_, alloc_wg::collections::CollectionAllocErr<Global>>(())
     /// ```
+    #[allow(clippy::needless_pass_by_value)]
     pub fn try_new_uninit_slice_in(
         len: usize,
         a: A,

--- a/src/raw_vec.rs
+++ b/src/raw_vec.rs
@@ -144,7 +144,7 @@ impl<T> RawVec<T> {
 
 impl<T, A: DeallocRef> RawVec<T, A> {
     /// Like `new` but parameterized over the choice of allocator for the returned `RawVec`.
-    pub fn new_in(mut a: A) -> Self {
+    pub fn new_in(a: A) -> Self {
         let capacity = if mem::size_of::<T>() == 0 { !0 } else { 0 };
         Self {
             ptr: Unique::empty(),
@@ -226,7 +226,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
     fn allocate_in(
         capacity: usize,
         zeroed: bool,
-        mut alloc: A,
+        alloc: A,
     ) -> Result<Self, CollectionAllocErr<A>>
     where
         A: AllocRef,
@@ -443,7 +443,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
                 return Err(CollectionAllocErr::CapacityOverflow);
             }
 
-            let (mut alloc, old_layout) = self.alloc_ref();
+            let (alloc, old_layout) = self.alloc_ref();
             let (new_cap, ptr) = if let Some(old_layout) = old_layout {
                 // Since we guarantee that we never allocate more than
                 // `isize::MAX` bytes, `elem_size * self.cap <= isize::MAX` as
@@ -524,7 +524,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
                 return Err(CapacityOverflow);
             }
 
-            let (mut alloc, old_layout) = if let (alloc, Some(layout)) = self.alloc_ref() {
+            let (alloc, old_layout) = if let (alloc, Some(layout)) = self.alloc_ref() {
                 (alloc, layout)
             } else {
                 return Ok(false); // nothing to double
@@ -701,7 +701,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
             return Ok(false);
         }
 
-        let (mut alloc, old_layout) = if let (alloc, Some(layout)) = self.alloc_ref() {
+        let (alloc, old_layout) = if let (alloc, Some(layout)) = self.alloc_ref() {
             (alloc, layout)
         } else {
             return Ok(false); // nothing to double
@@ -846,7 +846,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
 
         let _ = alloc_guard(new_layout.size().get(), new_layout.align().get())?;
 
-        let (mut alloc, old_layout) = self.alloc_ref();
+        let (alloc, old_layout) = self.alloc_ref();
         let result = if let Some(layout) = old_layout {
             unsafe { alloc.realloc(self.ptr.cast().into(), layout, new_layout) }
         } else {
@@ -888,7 +888,7 @@ enum ReserveStrategy {
 impl<T, A: DeallocRef> RawVec<T, A> {
     /// Frees the memory owned by the `RawVec` *without* trying to Drop its contents.
     pub fn dealloc_buffer(&mut self) {
-        if let (mut alloc, Some(layout)) = self.alloc_ref() {
+        if let (alloc, Some(layout)) = self.alloc_ref() {
             unsafe { alloc.dealloc(self.ptr.cast().into(), layout) }
         }
     }

--- a/src/raw_vec.rs
+++ b/src/raw_vec.rs
@@ -144,6 +144,7 @@ impl<T> RawVec<T> {
 
 impl<T, A: DeallocRef> RawVec<T, A> {
     /// Like `new` but parameterized over the choice of allocator for the returned `RawVec`.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new_in(a: A) -> Self {
         let capacity = if mem::size_of::<T>() == 0 { !0 } else { 0 };
         Self {
@@ -161,6 +162,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
     ///
     /// * if the requested capacity exceeds `usize::MAX` bytes.
     /// * on 32-bit platforms if the requested capacity exceeds `isize::MAX` bytes.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn with_capacity_in(capacity: usize, a: A) -> Self
     where
         A: AllocRef,
@@ -181,6 +183,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
     /// * `CapacityOverflow` if the requested capacity exceeds `usize::MAX` bytes.
     /// * `CapacityOverflow` on 32-bit platforms if the requested capacity exceeds `isize::MAX` bytes.
     /// * `AllocError` on OOM
+    #[allow(clippy::needless_pass_by_value)]
     pub fn try_with_capacity_in(capacity: usize, a: A) -> Result<Self, CollectionAllocErr<A>>
     where
         A: AllocRef,
@@ -196,6 +199,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
     ///
     /// * if the requested capacity exceeds `usize::MAX` bytes.
     /// * on 32-bit platforms if the requested capacity exceeds `isize::MAX` bytes.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn with_capacity_zeroed_in(capacity: usize, a: A) -> Self
     where
         A: AllocRef,
@@ -216,6 +220,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
     /// * `CapacityOverflow` if the requested capacity exceeds `usize::MAX` bytes.
     /// * `CapacityOverflow` on 32-bit platforms if the requested capacity exceeds `isize::MAX` bytes.
     /// * `AllocError` on OOM
+    #[allow(clippy::needless_pass_by_value)]
     pub fn try_with_capacity_zeroed_in(capacity: usize, a: A) -> Result<Self, CollectionAllocErr<A>>
     where
         A: AllocRef,
@@ -223,6 +228,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
         Self::allocate_in(capacity, true, a)
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     fn allocate_in(capacity: usize, zeroed: bool, alloc: A) -> Result<Self, CollectionAllocErr<A>>
     where
         A: AllocRef,

--- a/src/raw_vec.rs
+++ b/src/raw_vec.rs
@@ -223,11 +223,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
         Self::allocate_in(capacity, true, a)
     }
 
-    fn allocate_in(
-        capacity: usize,
-        zeroed: bool,
-        alloc: A,
-    ) -> Result<Self, CollectionAllocErr<A>>
+    fn allocate_in(capacity: usize, zeroed: bool, alloc: A) -> Result<Self, CollectionAllocErr<A>>
     where
         A: AllocRef,
     {

--- a/src/string.rs
+++ b/src/string.rs
@@ -566,6 +566,7 @@ impl String {
 
 impl<A: DeallocRef> String<A> {
     /// Like `new` but parameterized over the choice of allocator for the returned `String`.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn new_in(a: A) -> Self {
         Self {
@@ -577,6 +578,7 @@ impl<A: DeallocRef> String<A> {
     ///
     /// # Panics
     /// Panics if the allocation fails.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn with_capacity_in(capacity: usize, a: A) -> Self
     where
@@ -588,6 +590,7 @@ impl<A: DeallocRef> String<A> {
     }
 
     /// Like `with_capacity_in` but returns errors instead of panicking.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn try_with_capacity_in(capacity: usize, a: A) -> Result<Self, CollectionAllocErr<A>>
     where
@@ -602,6 +605,7 @@ impl<A: DeallocRef> String<A> {
     ///
     /// # Panics
     /// Panics if the allocation fails.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn from_str_in(s: &str, a: A) -> Self
     where
@@ -613,6 +617,7 @@ impl<A: DeallocRef> String<A> {
     }
 
     /// Like `from_str_in` but returns errors instead of panicking.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn try_from_str_in(s: &str, a: A) -> Result<Self, CollectionAllocErr<A>>
     where
@@ -703,6 +708,7 @@ impl<A: DeallocRef> String<A> {
     /// # Panics
     ///
     /// Panics if allocation fails.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn from_utf8_lossy_in(v: &[u8], a: A) -> Self
     where
         A: ReallocRef,
@@ -715,6 +721,7 @@ impl<A: DeallocRef> String<A> {
     }
 
     /// Like `from_utf8_lossy_in` but returns errors instead of panicking.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn try_from_utf8_lossy_in(v: &[u8], a: A) -> Result<Self, CollectionAllocErr<A>>
     where
         A: ReallocRef,
@@ -751,6 +758,7 @@ impl<A: DeallocRef> String<A> {
     }
 
     /// Like `from_utf16` but parameterized over the choice of allocator for the returned `String`.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn from_utf16_in(v: &[u16], a: A) -> Result<Self, FromUtf16Error>
     where
         A: ReallocRef,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -472,6 +472,7 @@ impl<T> Vec<T> {
 
 impl<T, A: DeallocRef> Vec<T, A> {
     /// Like `new` but parameterized over the choice of allocator for the returned `Vec`.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn new_in(a: A) -> Self {
         Self {
@@ -487,6 +488,7 @@ impl<T, A: DeallocRef> Vec<T, A> {
     ///
     /// * if the requested capacity exceeds `usize::MAX` bytes.
     /// * on 32-bit platforms if the requested capacity exceeds `isize::MAX` bytes.
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn with_capacity_in(capacity: usize, a: A) -> Self
     where
@@ -506,6 +508,7 @@ impl<T, A: DeallocRef> Vec<T, A> {
     /// * `CapacityOverflow` if the requested capacity exceeds `usize::MAX` bytes.
     /// * `CapacityOverflow` on 32-bit platforms if the requested capacity exceeds `isize::MAX` bytes.
     /// * `AllocError` on OOM
+    #[allow(clippy::needless_pass_by_value)]
     #[inline]
     pub fn try_with_capacity_in(capacity: usize, a: A) -> Result<Self, CollectionAllocErr<A>>
     where

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2185,7 +2185,7 @@ where
     #[must_use]
     #[inline]
     fn clone(&self) -> Self {
-        let mut b = self.buf.build_alloc().clone();
+        let b = self.buf.build_alloc().clone();
         let old_layout = self.buf.current_layout();
 
         unsafe {
@@ -2463,7 +2463,7 @@ where
 }
 
 impl<T, A: ReallocRef> SpecExtend<T, IntoIter<T, A>, A> for Vec<T, A> {
-    fn try_from_iter_in(iter: IntoIter<T, A>, mut a: A) -> Result<Self, CollectionAllocErr<A>> {
+    fn try_from_iter_in(iter: IntoIter<T, A>, a: A) -> Result<Self, CollectionAllocErr<A>> {
         // A common case is passing a vector into a function which immediately
         // re-collects into a vector. We can short circuit this if the IntoIter
         // has not been advanced at all.

--- a/tests/heap.rs
+++ b/tests/heap.rs
@@ -13,7 +13,7 @@ fn std_heap_overaligned_request() {
     check_overalign_requests(Global)
 }
 
-fn check_overalign_requests<T: AllocRef>(mut allocator: T)
+fn check_overalign_requests<T: AllocRef>(allocator: T)
 where
     T::Error: Debug,
 {


### PR DESCRIPTION
This allows the traits to be implemented on immutable references, which is necessary whenever we have non-static instance of an allocator. Internal mutability can still be achieved through `Cell` or `RefCell`.

I wrote a [bump allocator](https://github.com/Wodann/alloc-bump-rs) that requires this change.