### PR TITLE
Make `DeallocRef::get_build_alloc` move into the `BuildAlloc` type, and rename suitably.

### DIFF
--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -184,7 +184,7 @@ pub trait BuildAllocRef: Sized {
 pub trait DeallocRef: Sized {
     type BuildAlloc: BuildAllocRef<Ref = Self>;
 
-    fn get_build_alloc(&mut self) -> Self::BuildAlloc;
+    fn into_build_alloc(self) -> Self::BuildAlloc;
 
     /// # Safety
     ///
@@ -340,7 +340,7 @@ impl_buildalloc_alloc_zst!(System);
 impl DeallocRef for Global {
     type BuildAlloc = Self;
 
-    fn get_build_alloc(&mut self) -> Self::BuildAlloc {
+    fn into_build_alloc(self) -> Self::BuildAlloc {
         Self
     }
 
@@ -395,7 +395,7 @@ impl ReallocRef for Global {
 impl DeallocRef for System {
     type BuildAlloc = Self;
 
-    fn get_build_alloc(&mut self) -> Self::BuildAlloc {
+    fn into_build_alloc(self) -> Self::BuildAlloc {
         Self
     }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -227,7 +227,7 @@ impl<T, A: AllocRef> Box<T, A> {
         } else {
             NonNull::dangling()
         };
-        unsafe { Ok(Self::from_raw_in(ptr.as_ptr(), a.get_build_alloc())) }
+        unsafe { Ok(Self::from_raw_in(ptr.as_ptr(), a.into_build_alloc())) }
     }
 
     /// Constructs a new box with uninitialized contents in a specified allocator.
@@ -286,7 +286,7 @@ impl<T, A: AllocRef> Box<T, A> {
         } else {
             NonNull::dangling()
         };
-        unsafe { Ok(Box::from_raw_in(ptr.as_ptr(), a.get_build_alloc())) }
+        unsafe { Ok(Box::from_raw_in(ptr.as_ptr(), a.into_build_alloc())) }
     }
 
     /// Constructs a new `Pin<Box<T, A>>` with the specified allocator. If `T` does not implement
@@ -408,7 +408,7 @@ impl<T, A: AllocRef> Box<[T], A> {
             let slice = slice::from_raw_parts_mut(ptr.as_ptr(), len);
             Ok(Box::from_raw_in(
                 NonNull::from(slice).as_ptr(),
-                a.get_build_alloc(),
+                a.into_build_alloc(),
             ))
         }
     }

--- a/src/raw_vec.rs
+++ b/src/raw_vec.rs
@@ -146,12 +146,12 @@ impl<T> RawVec<T> {
 
 impl<T, A: DeallocRef> RawVec<T, A> {
     /// Like `new` but parameterized over the choice of allocator for the returned `RawVec`.
-    pub fn new_in(mut a: A) -> Self {
+    pub fn new_in(a: A) -> Self {
         let capacity = if mem::size_of::<T>() == 0 { !0 } else { 0 };
         Self {
             ptr: Unique::dangling(),
             capacity,
-            build_alloc: a.get_build_alloc(),
+            build_alloc: a.into_build_alloc(),
         }
     }
 
@@ -249,7 +249,7 @@ impl<T, A: DeallocRef> RawVec<T, A> {
         Ok(Self {
             ptr: ptr.into(),
             capacity,
-            build_alloc: alloc.get_build_alloc(),
+            build_alloc: alloc.into_build_alloc(),
         })
     }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2468,7 +2468,7 @@ where
 }
 
 impl<T, A: ReallocRef> SpecExtend<T, IntoIter<T, A>, A> for Vec<T, A> {
-    fn try_from_iter_in(iter: IntoIter<T, A>, mut a: A) -> Result<Self, CollectionAllocErr<A>> {
+    fn try_from_iter_in(iter: IntoIter<T, A>, a: A) -> Result<Self, CollectionAllocErr<A>> {
         // A common case is passing a vector into a function which immediately
         // re-collects into a vector. We can short circuit this if the IntoIter
         // has not been advanced at all.
@@ -2479,7 +2479,7 @@ impl<T, A: ReallocRef> SpecExtend<T, IntoIter<T, A>, A> for Vec<T, A> {
                     iter.buf.ptr(),
                     iter.len(),
                     iter.buf.capacity(),
-                    a.get_build_alloc(),
+                    a.into_build_alloc(),
                 );
                 mem::forget(iter);
                 Ok(vec)


### PR DESCRIPTION
All of our uses of this function drop the `DeallocRef` type right after. This breaking
change allows us to avoid cloning allocators, which can be relatively expensive if Arcs
are involved.